### PR TITLE
Update run.sh

### DIFF
--- a/image/run.sh
+++ b/image/run.sh
@@ -39,7 +39,7 @@ fi
 # generate logrotate config
 #################################################
 
-log_directory=$(dirname $LOGROTATE_LOGS)
+log_directory=$(dirname "$LOGROTATE_LOGS")
 if [[ ! -e $log_directory ]]; then
   log ERROR "Directory [$log_directory] does not exist! Verify LOGROTATE_LOGS environment variable and volume mount."
   exit 1


### PR DESCRIPTION
Double quotes around $LOGROTATE_LOGS prevents bash from expanding a variable content like "/var/log/traefik/*.log" that drops an error with dirname and causing the script to fail.