### PR TITLE
Update Dockerfile to include tzdata

### DIFF
--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -29,6 +29,7 @@ RUN --mount=type=bind,source=.shared,target=/mnt/shared \
      gzip \
      logrotate \
      tar \
+     tzdata \
      tini \
      && \
   #


### PR DESCRIPTION
Container needs `tzdata` to respect the TZ environment variable sent via docker run or docker-compose.